### PR TITLE
スレッドの縦線が繋がるようにした

### DIFF
--- a/frontend/assets/scss/timeline.scss
+++ b/frontend/assets/scss/timeline.scss
@@ -74,7 +74,7 @@
       }
     }
 
-    .Refresh{
+    .Refresh {
       margin-right: 3px;
       padding: 0;
       border: none;
@@ -84,7 +84,7 @@
       color: $git-black;
       cursor: pointer;
       .material-icons {
-          font-size: 20px;
+        font-size: 20px;
       }
       &:hover {
         background: rgb(240, 240, 240);
@@ -130,7 +130,20 @@
         'areaIcon         areaText  areaText areaText'
         'dottedThreadLine readmore  readmore readmore';
 
+      &.reply > .iconItem::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 50%;
+        transform: translateX(-70%); // 目測で調整
+        height: 12px;
+        width: 3px;
+        background: $border;
+        margin-top: -12px;
+      }
+
       & > .iconItem {
+        position: relative;
         grid-area: areaIcon;
         display: flex;
         flex-direction: column;
@@ -143,12 +156,17 @@
           justify-content: center;
         }
       }
-      & > .dottedThreadLine {
+
+      & > .threadLine {
         grid-area: dottedThreadLine;
+        border-right: 3px solid $border;
+        &.dotted {
+          border-right: 3px dotted $border;
+        }
         margin: 0 auto;
-        border-right: 3px dotted $border;
         transition: all 0.3s;
       }
+
       & > .titleItem {
         grid-area: areaTitle;
         min-width: 0;
@@ -254,15 +272,15 @@
       min-height: 60px;
     }
 
-    .loading{
-      img{
+    .loading {
+      img {
         margin: 30px auto;
       }
     }
   }
 }
 
-.modal-content{
+.modal-content {
   .postTextBox {
     width: 100%;
     height: 100%;
@@ -271,9 +289,9 @@
   .repo {
     padding-bottom: 15px;
     color: gray;
-    .address{
+    .address {
       color: $git-blue;
-      background-color: #EBF5FF;
+      background-color: #ebf5ff;
       padding: 5px 10px;
       border-radius: 7px;
     }

--- a/frontend/components/Comment.vue
+++ b/frontend/components/Comment.vue
@@ -2,6 +2,7 @@
   <div
     class="comment"
     :class="{
+      reply: type === 'reply',
       thread: thread,
     }"
   >
@@ -12,7 +13,11 @@
       />
       <div v-if="thread" class="thread-line"></div>
     </div>
-    <div v-if="showReadMoreIcon" class="dottedThreadLine"></div>
+    <div
+      v-if="readmore || fold"
+      class="threadLine"
+      :class="{ dotted: readmore }"
+    ></div>
     <div class="titleItem">
       <div v-if="(type === 'issue') | (type === 'pullRequest')">
         <a :href="url" target="_blank" class="titleLine">

--- a/frontend/components/ContentBox.vue
+++ b/frontend/components/ContentBox.vue
@@ -78,6 +78,7 @@ import { Content } from '@/models/types'
 
 
 export default Vue.extend({
+  name: 'ContentBox',
   props: {
     content: {
       type: Object,

--- a/frontend/components/Timeline.vue
+++ b/frontend/components/Timeline.vue
@@ -44,10 +44,11 @@
 import Vue from 'vue'
 import { Content, Label } from '@/models/types'
 import axios from 'axios'
+// @ts-ignore
+import { Octicon, Octicons } from 'octicons-vue'
 
 axios.defaults.baseURL = 'http://localhost:5000'
 
-const { Octicon, Octicons } = require('octicons-vue')
 
 type LabelItem = {
   label: Label


### PR DESCRIPTION
## やったこと
- スレッドの縦線とアイコンの隙間が生まれないようにした。
  - Commentのtypeがreplyの場合のみ、ユーザーアイコンの上部にも線を出すようにした

![image](https://user-images.githubusercontent.com/38308823/124361780-ca628e00-dc6b-11eb-92ea-7e2bb9d62467.png)
