### PR TITLE
[fix]シンタックスハイライトが効かない時がある

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
   "editor.formatOnSave": true, // ファイル保存時にPrettierでフォーマット
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true // ファイル保存時にESLintでフォーマット
-  }
+  },
+  "[vue]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
 }

--- a/webapp/components/Comment.vue
+++ b/webapp/components/Comment.vue
@@ -233,6 +233,16 @@ export default Vue.extend({
       })
     },
   },
+  updated() {
+    const elms = document.querySelectorAll('.language-vue')
+    elms.forEach((elm) => {
+      elm.classList.remove('language-vue')
+      elm.classList.add('language-html')
+    })
+    if (document.getElementsByTagName('code').length > 0) {
+      hljs.highlightAll()
+    }
+  },
   mounted() {
     this.$props.addCallbacks(() => {
       if (
@@ -246,14 +256,6 @@ export default Vue.extend({
     if (this.$refs.textarea != null && this.$refs.textarea instanceof Element) {
       const tmp = this.$refs.textarea.clientHeight
       this.height = tmp
-    }
-    const elms = document.querySelectorAll('.language-vue')
-    elms.forEach((elm) => {
-      elm.classList.remove('language-vue')
-      elm.classList.add('language-html')
-    })
-    if (document.getElementsByTagName('code').length > 0) {
-      hljs.highlightAll()
     }
   },
   methods: {


### PR DESCRIPTION
close #208 

「返信をさらに表示」を押すとその中のコメントのシンタックスハイライトが効いていなかった。
<img width="347" alt="スクリーンショット 2021-09-29 23 35 30" src="https://user-images.githubusercontent.com/65712721/135290519-00568e75-33da-4686-ba5e-e33485015f15.png">
↓
<img width="312" alt="スクリーンショット 2021-09-29 23 37 08" src="https://user-images.githubusercontent.com/65712721/135290776-907c59d3-b043-4834-a3d9-1fe76b1451a1.png">


シンタックスハイライトの処理をmountedではなくupdatedに書いたら直った
