### PR TITLE
折り畳みにスクロールを適用

### DIFF
--- a/webapp/assets/scss/timeline.scss
+++ b/webapp/assets/scss/timeline.scss
@@ -76,10 +76,8 @@
     overflow-y: scroll;
 
     & .comment {
-      padding-top: 12px;
-      padding-left: 12px;
-      padding-right: 12px;
-      padding-bottom: 12px;
+      position: relative;
+      padding: 12px;
       border-bottom: 1px solid;
       display: grid;
       grid-template-rows: min-content 1fr;
@@ -142,6 +140,7 @@
             font-size: 12px;
             margin-bottom: 4px;
             & > .number {
+              display: inline-block;
               font-weight: normal;
             }
           }
@@ -194,8 +193,8 @@
         margin: 0px 7px;
         word-break: break-all;
         font-size: 12px;
-        overflow-y: hidden;
         overflow-x: scroll;
+        overflow-y: scroll;
         .labels {
           display: -webkit-box;
           display: -ms-flexbox;
@@ -229,6 +228,28 @@
               padding: 4px 12px;
               border: 1px solid;
             }
+          }
+        }
+
+        & > .fold-icon-button {
+          position: absolute;
+          bottom: 12px;
+          right: 18px;
+          background-color: rgba(0, 0, 0, 0.2);
+          border: none;
+          border-radius: 100%;
+          width: 24px;
+          height: 24px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+
+          &:hover {
+            cursor: pointer;
+          }
+
+          & > span {
+            font-size: 14px;
           }
         }
       }

--- a/webapp/components/Comment.vue
+++ b/webapp/components/Comment.vue
@@ -102,10 +102,19 @@
       </div>
       <!-- eslint-disable-next-line vue/no-v-html -->
       <div class="textItemCon" v-html="htmlBody"></div>
+      <button
+        v-if="showFoldIcon"
+        class="fold-icon-button"
+        @click="LongCommentClick"
+      >
+        <span class="material-icons">{{
+          isLongCommentOpened ? 'unfold_less' : 'unfold_more'
+        }}</span>
+      </button>
     </div>
-    <button v-if="showFoldIcon" class="buttonItem" @click="LongCommentClick">
+    <!-- <button v-if="showFoldIcon" class="buttonItem" @click="LongCommentClick">
       {{ buttonMark }}
-    </button>
+    </button> -->
     <div v-if="readmore" class="readmoreItem">
       <a class="readmore" @click="$emit('toggleShowingAll')">
         返信をさらに表示
@@ -121,11 +130,11 @@
 
 <script lang="ts">
 import Vue, { PropType, PropOptions } from 'vue'
-import { Label, User } from '@/models/types'
 // @ts-ignore
 import { Octicon, Octicons } from 'octicons-vue'
 import hljs from 'highlight.js'
 import sanitizeHTML from 'sanitize-html'
+import { Label, User } from '@/models/types'
 
 type DataType = {
   Octicons: any
@@ -225,7 +234,7 @@ export default Vue.extend({
     },
     textHeight(): string {
       if (!this.isLongCommentOpened && this.height > this.MAX_COMMENT_HEIGT) {
-        return '100px'
+        return '250px'
       } else {
         return '100%'
       }


### PR DESCRIPTION
## やったこと
- 長文の投稿で折りたたまれている場合、スクロールが可能にした
- 投稿のデフォルトの最大高さを100pxから250pxに増やした

![image](https://user-images.githubusercontent.com/38308823/137631704-b457a964-c2e4-45ce-a770-9efc12c06031.png)
